### PR TITLE
chore: bump browser versions for sauce labs

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -42,12 +42,12 @@ module.exports = function(config) {
       'SL_CHROME': {
         base: 'SauceLabs',
         browserName: 'chrome',
-        version: '52'
+        version: 'latest'
       },
       'SL_FIREFOX': {
         base: 'SauceLabs',
         browserName: 'firefox',
-        version: '46'
+        version: 'latest'
       },
       'SL_IE9': {
         base: 'SauceLabs',
@@ -67,17 +67,29 @@ module.exports = function(config) {
         platform: 'Windows 8.1',
         version: '11'
       },
-      'SL_EDGE': {
+      'SL_EDGE13': {
         base: 'SauceLabs',
         browserName: 'MicrosoftEdge',
         platform: 'Windows 10',
         version: '13.10586'
+      },
+      'SL_EDGE14': {
+        base: 'SauceLabs',
+        browserName: 'MicrosoftEdge',
+        platform: 'Windows 10',
+        version: '14.14393'
       },
       'SL_SAFARI9': {
         base: 'SauceLabs',
         browserName: 'safari',
         platform: 'OS X 10.11',
         version: '9.0'
+      },
+      'SL_SAFARI10': {
+        base: 'SauceLabs',
+        browserName: 'safari',
+        platform: 'OS X 10.11',
+        version: '10.0'
       }
     },
 


### PR DESCRIPTION
- updating evergreen browsers to `latest` version
- adding `edge 14` and `safari 10`